### PR TITLE
feat: initial backend and frontend setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+FLUX_API_KEY=your_flux_key
+REPLICATE_API_KEY=your_replicate_key

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Node
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # Refraiming
-An AI-based tool to edit high-quaility photographs using text descriptions
+
+An AI-based tool to edit high-quality photographs using text descriptions.
+
+## Setup (macOS/Linux/WSL2)
+1. Install Python and Node.js.
+2. Create a virtual environment and install backend dependencies:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Install frontend dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+## API Accounts
+Create accounts with Black Forest Labs (Flux) and Replicate. Place your API tokens in a `.env` file:
+```
+FLUX_API_KEY=your_flux_key
+REPLICATE_API_KEY=your_replicate_key
+```
+
+## Running Locally
+Start the FastAPI backend:
+```bash
+uvicorn app.main:app --reload
+```
+Start the React frontend:
+```bash
+cd frontend
+npm run dev
+```
+The frontend proxy is configured to forward `/api` requests to the backend.
+
+## Secret Handling
+Never commit the `.env` file or any keys. Use `.env.example` as a template for local development.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,78 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import List
+from PIL import Image
+from io import BytesIO
+
+app = FastAPI()
+
+MAX_DIMENSION = 2048
+
+class EditRequest(BaseModel):
+    prompt: str
+
+class SessionState:
+    """In-memory storage for a single editing session."""
+    def __init__(self) -> None:
+        self.original: bytes | None = None
+        self.history: List[bytes] = []
+        self.cost_eur: float = 0.0
+
+state = SessionState()
+
+def _downscale_image(data: bytes) -> bytes:
+    """Downscale image so longest side equals MAX_DIMENSION using LANCZOS."""
+    with Image.open(BytesIO(data)) as img:
+        width, height = img.size
+        if max(width, height) <= MAX_DIMENSION:
+            buf = BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+        if width >= height:
+            new_w = MAX_DIMENSION
+            new_h = int(height * MAX_DIMENSION / width)
+        else:
+            new_h = MAX_DIMENSION
+            new_w = int(width * MAX_DIMENSION / height)
+        resized = img.resize((new_w, new_h), Image.LANCZOS)
+        buf = BytesIO()
+        resized.save(buf, format="PNG")
+        return buf.getvalue()
+
+@app.post("/upload")
+async def upload_image(file: UploadFile = File(...)):
+    data = await file.read()
+    state.original = data
+    processed = _downscale_image(data)
+    state.history = [processed]
+    state.cost_eur = 0.0
+    with Image.open(BytesIO(processed)) as img:
+        width, height = img.size
+    return {"width": width, "height": height, "cost_eur": state.cost_eur}
+
+@app.post("/edit")
+async def edit_image(request: EditRequest):
+    if not state.history:
+        raise HTTPException(status_code=400, detail="No image uploaded")
+    # Placeholder for call to Flux 1 Kontext API.
+    # For now, we simply re-use the latest image and add a fixed cost.
+    latest = state.history[-1]
+    state.history.append(latest)
+    state.cost_eur += 0.05
+    return {"cost_eur": state.cost_eur, "prompt": request.prompt}
+
+@app.post("/undo")
+async def undo_last_edit():
+    if len(state.history) <= 1:
+        raise HTTPException(status_code=400, detail="Nothing to undo")
+    state.history.pop()
+    return {"cost_eur": state.cost_eur, "edits_remaining": len(state.history)}
+
+@app.post("/finalize")
+async def finalize_image():
+    if not state.history:
+        raise HTTPException(status_code=400, detail="No image uploaded")
+    # Placeholder for Real-ESRGAN upscale and JPEG export.
+    state.cost_eur += 0.01
+    return JSONResponse({"message": "Upscale placeholder", "cost_eur": state.cost_eur})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Refraiming</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "refraiming-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-3xl font-bold">Refraiming</h1>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pillow
+python-dotenv
+requests


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with image upload, edit, undo, and finalize endpoints
- create React/Vite frontend skeleton with Tailwind configuration
- document setup steps and environment variables

## Testing
- `python -m py_compile app/main.py`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f41da574c833389a38360f4e750c8