### PR TITLE
test: add backend unit and workflow tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel
 app = FastAPI()
 
 MAX_DIMENSION = 2048
+EDIT_COST_EUR = 0.05
+FINALIZE_COST_EUR = 0.01
 
 
 class EditRequest(BaseModel):
@@ -67,7 +69,7 @@ async def edit_image(request: EditRequest):
     # For now, we simply re-use the latest image and add a fixed cost.
     latest = state.history[-1]
     state.history.append(latest)
-    state.cost_eur += 0.05
+    state.cost_eur += EDIT_COST_EUR
     return {"cost_eur": state.cost_eur, "prompt": request.prompt}
 
 
@@ -84,5 +86,5 @@ async def finalize_image():
     if not state.history:
         raise HTTPException(status_code=400, detail="No image uploaded")
     # Placeholder for Real-ESRGAN upscale and JPEG export.
-    state.cost_eur += 0.01
+    state.cost_eur += FINALIZE_COST_EUR
     return JSONResponse({"message": "Upscale placeholder", "cost_eur": state.cost_eur})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,21 +1,111 @@
 from io import BytesIO
 
+import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 
-from app.main import app
+from app.main import (
+    EDIT_COST_EUR,
+    FINALIZE_COST_EUR,
+    MAX_DIMENSION,
+    _downscale_image,
+    app,
+    state,
+)
 
 client = TestClient(app)
 
 
-def test_upload_image() -> None:
-    img = Image.new("RGB", (100, 100), color="red")
+@pytest.fixture(autouse=True)
+def reset_state() -> None:
+    """Ensure each test starts with a clean session state."""
+    state.original = None
+    state.history = []
+    state.cost_eur = 0.0
+    yield
+    state.original = None
+    state.history = []
+    state.cost_eur = 0.0
+
+
+def create_image(size: tuple[int, int]) -> BytesIO:
+    img = Image.new("RGB", size, color="red")
     buf = BytesIO()
     img.save(buf, format="PNG")
     buf.seek(0)
+    return buf
+
+
+def test_downscale_image_no_resize() -> None:
+    buf = create_image((100, 50))
+    data = _downscale_image(buf.getvalue())
+    with Image.open(BytesIO(data)) as img:
+        assert img.size == (100, 50)
+
+
+def test_downscale_image_resizes() -> None:
+    buf = create_image((4096, 2048))
+    data = _downscale_image(buf.getvalue())
+    with Image.open(BytesIO(data)) as img:
+        assert max(img.size) == MAX_DIMENSION
+
+
+def test_upload_image() -> None:
+    buf = create_image((100, 100))
     files = {"file": ("test.png", buf, "image/png")}
     response = client.post("/upload", files=files)
     assert response.status_code == 200
     data = response.json()
     assert data["width"] == 100
     assert data["height"] == 100
+
+
+def test_edit_requires_upload() -> None:
+    response = client.post("/edit", json={"prompt": "test"})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "No image uploaded"
+
+
+def test_edit_updates_cost() -> None:
+    buf = create_image((100, 100))
+    files = {"file": ("test.png", buf, "image/png")}
+    client.post("/upload", files=files)
+    cost_before = state.cost_eur
+    response = client.post("/edit", json={"prompt": "hello"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cost_eur"] == pytest.approx(cost_before + EDIT_COST_EUR)
+
+
+def test_undo_requires_history() -> None:
+    response = client.post("/undo")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Nothing to undo"
+
+
+def test_undo_reverts_edit() -> None:
+    buf = create_image((100, 100))
+    files = {"file": ("test.png", buf, "image/png")}
+    client.post("/upload", files=files)
+    client.post("/edit", json={"prompt": "hello"})
+    response = client.post("/undo")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["edits_remaining"] == 1
+
+
+def test_finalize_requires_upload() -> None:
+    response = client.post("/finalize")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "No image uploaded"
+
+
+def test_finalize_updates_cost() -> None:
+    buf = create_image((100, 100))
+    files = {"file": ("test.png", buf, "image/png")}
+    client.post("/upload", files=files)
+    cost_before = state.cost_eur
+    response = client.post("/finalize")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cost_eur"] == pytest.approx(cost_before + FINALIZE_COST_EUR)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,44 @@
+from io import BytesIO
+
+from fastapi.testclient import TestClient
+from PIL import Image
+import pytest
+
+from app.main import EDIT_COST_EUR, FINALIZE_COST_EUR, app, state
+
+client = TestClient(app)
+
+
+def create_image(size):
+    img = Image.new("RGB", size, color="blue")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
+def test_full_workflow():
+    state.original = None
+    state.history = []
+    state.cost_eur = 0.0
+
+    buf = create_image((3000, 1500))
+    files = {"file": ("big.png", buf, "image/png")}
+    response = client.post("/upload", files=files)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["width"] == 2048
+    assert data["height"] == 1024
+
+    response = client.post("/edit", json={"prompt": "add sun"})
+    assert response.status_code == 200
+    assert response.json()["cost_eur"] == pytest.approx(EDIT_COST_EUR)
+
+    response = client.post("/undo")
+    assert response.status_code == 200
+    assert response.json()["edits_remaining"] == 1
+
+    response = client.post("/finalize")
+    assert response.status_code == 200
+    expected_total = EDIT_COST_EUR + FINALIZE_COST_EUR
+    assert response.json()["cost_eur"] == pytest.approx(expected_total)


### PR DESCRIPTION
## Summary
- expose cost constants for edit and finalize operations and apply them in backend
- update unit and end-to-end tests to leverage these constants and check error details

## Testing
- `pytest --cov=app --cov-report=term --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4e95fde88333bb4236f0790e1837